### PR TITLE
Fix unsupported method head.

### DIFF
--- a/pywsus.py
+++ b/pywsus.py
@@ -118,6 +118,14 @@ class WSUSBaseServer(BaseHTTPRequestHandler):
         self.send_header('X-Powered-By', 'ASP.NET')
         self.end_headers()
 
+    def do_HEAD(self):
+        logging.debug('HEAD request,\nPath: {path}\nHeaders:\n{headers}\n'.format(path=self.path, headers=self.headers))
+
+        if self.path.find(".exe"):
+            logging.info("Requested: {path}".format(path=self.path))
+
+            self._set_response(True)
+
     def do_GET(self):
         logging.debug('GET request,\nPath: {path}\nHeaders:\n{headers}\n'.format(path=self.path, headers=self.headers))
 

--- a/pywsus.py
+++ b/pywsus.py
@@ -114,6 +114,7 @@ class WSUSBaseServer(BaseHTTPRequestHandler):
         else:
             self.send_header('Content-type', 'text/xml; chartset=utf-8')
 
+        self.send_header("Content-Length", len(update_handler.executable))
         self.send_header('X-AspNet-Version', '4.0.30319')
         self.send_header('X-Powered-By', 'ASP.NET')
         self.end_headers()


### PR DESCRIPTION
I tried pywsus on a "Windows 10 Enterprise 2015 LTSB" (Build 10240), and ran into two problems:

1. The WSUS client made several HEAD-Requests to the server which resulted in the error message mentioned in #1: `code 501, message Unsupported method ('HEAD')`
2. After fixing that the client requested PsExec64.exe but closed the connection early resulting in `socket.error: [Errno 104] Connection reset by peer` or `error: [Errno 32] Broken pipe`.

Problem 1 is fixed by answering to HEAD requests, problem 2 is fixed by sending the `Content-Length` header. This PR implements both fixes. This also fixes #1.