### PR TITLE
Add RegisterComputer Response

### DIFF
--- a/pywsus.py
+++ b/pywsus.py
@@ -153,7 +153,7 @@ class WSUSBaseServer(BaseHTTPRequestHandler):
             data = BeautifulSoup(update_handler.get_cookie_xml, "xml")
 
         elif soap_action == '"http://www.microsoft.com/SoftwareDistribution/Server/ClientWebService/RegisterComputer"':
-            # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wusp/36a5d99a-a3ca-439d-bcc5-7325ff6b91e2
+            # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wusp/b0f2a41f-4b96-42a5-b84f-351396293033
             data = BeautifulSoup(update_handler.register_computer_xml, "xml")
 
         elif soap_action == '"http://www.microsoft.com/SoftwareDistribution/Server/ClientWebService/SyncUpdates"':

--- a/pywsus.py
+++ b/pywsus.py
@@ -18,6 +18,7 @@ class WSUSUpdateHandler:
     def __init__(self, executable_file, executable_name, client_address):
         self.get_config_xml = ''
         self.get_cookie_xml = ''
+        self.register_computer_xml = ''
         self.sync_updates_xml = ''
         self.get_extended_update_info_xml = ''
         self.report_event_batch_xml = ''
@@ -55,6 +56,10 @@ class WSUSUpdateHandler:
 
             with open('{}/resources/get-cookie.xml'.format(path), 'r') as file:
                 self.get_cookie_xml = file.read().format(expire=self.get_expire(), cookie=self.get_cookie())
+                file.close()
+
+            with open('{}/resources/register-computer.xml'.format(path), 'r') as file:
+                self.register_computer_xml = file.read()
                 file.close()
 
             with open('{}/resources/sync-updates.xml'.format(path), 'r') as file:
@@ -146,6 +151,10 @@ class WSUSBaseServer(BaseHTTPRequestHandler):
         elif soap_action == '"http://www.microsoft.com/SoftwareDistribution/Server/ClientWebService/GetCookie"':
             # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wusp/36a5d99a-a3ca-439d-bcc5-7325ff6b91e2
             data = BeautifulSoup(update_handler.get_cookie_xml, "xml")
+
+        elif soap_action == '"http://www.microsoft.com/SoftwareDistribution/Server/ClientWebService/RegisterComputer"':
+            # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wusp/36a5d99a-a3ca-439d-bcc5-7325ff6b91e2
+            data = BeautifulSoup(update_handler.register_computer_xml, "xml")
 
         elif soap_action == '"http://www.microsoft.com/SoftwareDistribution/Server/ClientWebService/SyncUpdates"':
             # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wusp/6b654980-ae63-4b0d-9fae-2abb516af894

--- a/resources/register-computer.xml
+++ b/resources/register-computer.xml
@@ -1,0 +1,1 @@
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><RegisterComputerResponse xmlns="http://www.microsoft.com/SoftwareDistribution/Server/ClientWebService"></RegisterComputerResponse></s:Body></s:Envelope>


### PR DESCRIPTION
Ran into an issue where the client machine would send a `RegisterComputer` request and pywsus would just hang with `WARNING:root:SOAP Action not handled` - which is weird because the `get-config.xml` says registration is not required (`<IsRegistrationRequired>false</IsRegistrationRequired>`). 

According to Microsoft, when a client sends a `RegisterComputer` - "If no faults occur during the operation, the server MUST return a RegisterComputerResponse message to the client." 
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wusp/1c84550d-ba7b-4174-9b0d-bf7cb1a70238

Still not sure why the client was sending `RegisterComputer`, but was able to appease by just adding an additional elif to handle it. Hopefully it will be helpful for others. 