### PR TITLE
update lxml to 4.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 beautifulsoup4==4.9.1
-lxml==4.6.2
+lxml==4.9.1
 soupsieve==2.0.1


### PR DESCRIPTION
I had the exception bs4.FeatureNotFound when using the default requirements. After upgrading to lxml 4.9.1 this was solved.